### PR TITLE
[FIX] Create a symlink from nova/vendor to /vendor if none exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /dist/storage
 /storage/*.key
 /nova/vendor
+/vendor
 /.idea
 /.vscode
 /.vagrant

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
     "scripts": {
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
+            "@php -r \"file_exists('nova/vendor') && !file_exists('vendor') && symlink('nova/vendor', 'vendor');\"",
             "@php artisan package:discover --ansi"
         ],
         "post-root-package-install": [


### PR DESCRIPTION
Please prefix your pull request with one of the following: __[FEATURE]__ __[FIX]__ __[IMPROVEMENT]__.

__In raising this pull request, I confirm the following (please check boxes):__

- [x] I have read and understood the [contributors guide](CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

__My familiarity with the project is as follows (check one):__

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [x] I am an active contributor to the project.

| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| BC breaks?     | no
| Deprecations?  | no
| Fixed issues   | #157 
| Related issues | 

---

This will make sure that vendor can live in nova/vendor but anything that by default looks for vendor folder in root will find it still, and work as expected.

PHP's symlink works on both linux and Windows machines, so this should be consistent, and the symlink generation will really only happen once, unless the vendor symlink was deleted, so it is ensured to always exist and be referenced.

Fixes #157