### PR TITLE
Upgrade to Vue 2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "beyondcode/laravel-dump-server": "^1.0",
         "filp/whoops": "^2.0",
         "fzaninotto/faker": "^1.4",
-        "mikey179/vfsStream": "^1.6",
+        "mikey179/vfsstream": "^1.6",
         "mockery/mockery": "^1.0",
         "nunomaduro/collision": "^2.0",
         "phpunit/phpunit": "^7.0",

--- a/nova/resources/js/components/pickers/IconSetPicker.vue
+++ b/nova/resources/js/components/pickers/IconSetPicker.vue
@@ -6,7 +6,7 @@
         placeholder-search="Find an icon set"
         :filter-function="filterIconSets"
     >
-        <template slot="picker-select-input" slot-scope="{ selected }">
+        <template v-slot:picker-select-input="{ selected }">
             <component
                 :is="selected.component"
                 :key="selected.value"
@@ -15,7 +15,7 @@
             {{ selected.name }}
         </template>
 
-        <template slot="picker-select-item" slot-scope="{ item }">
+        <template v-slot:picker-select-item="{ item }">
             <component
                 :is="item.component"
                 :name="item.icon"

--- a/nova/resources/js/components/pickers/LayoutPicker.vue
+++ b/nova/resources/js/components/pickers/LayoutPicker.vue
@@ -6,11 +6,11 @@
         placeholder-search="Find a layout"
         :filter-function="filterLayouts"
     >
-        <template slot="picker-select-input" slot-scope="{ selected }">
+        <template v-slot:picker-select-input="{ selected }">
             {{ selected.name }}
         </template>
 
-        <template slot="picker-select-item" slot-scope="{ item }">
+        <template v-slot:picker-select-item="{ item }">
             {{ item.name }}
         </template>
     </base-picker>

--- a/package.json
+++ b/package.json
@@ -16,19 +16,18 @@
         "@fortawesome/free-regular-svg-icons": "^5.6.3",
         "@fortawesome/free-solid-svg-icons": "^5.6.3",
         "@fortawesome/vue-fontawesome": "^0.1.4",
-        "animate.css": "^3.7.0",
+        "animate.css": "^3.7",
         "axios": "^0.18",
-        "feather-icons": "^4.10.0",
+        "feather-icons": "^4.10",
         "laravel-mix": "^4.0.7",
         "laravel-mix-tailwind": "^0.1.0",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17",
         "popper.js": "^1.12",
         "resolve-url-loader": "^2.3.1",
         "sweetalert2": "^7.33.1",
         "tailwindcss": "^0.7.3",
-        "vue": "^2.5.17",
-        "vue-feather-icons": "^4.7.1",
-        "vue-material-design-icons": "^2.6.0",
+        "vue": "^2.6.0",
+        "vue-feather-icons": "^4.7",
         "vue-on-click-outside": "^1.0.3",
         "vue-svgicon": "^3.2.2"
     },
@@ -41,6 +40,6 @@
         "eslint-plugin-vue": "^5.0.0-beta.3",
         "less": "^3.9.0",
         "less-loader": "^4.1.0",
-        "vue-template-compiler": "^2.5.21"
+        "vue-template-compiler": "^2.6.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -897,7 +897,7 @@ alphanum-sort@^1.0.0:
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
 
-animate.css@^3.7.0:
+animate.css@^3.7:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/animate.css/-/animate.css-3.7.0.tgz#5de25d1ee5fba11ba6a1e2c4fa568f512eb7d4da"
   integrity sha512-u3iMXDJr0cxMdQocIciDiou9Au4L5f9uT+/jCtprw3s1j3HcfCuI+khF+90Ps2KdsEhM2soF7SXB4WUvI3HlXg==
@@ -2995,7 +2995,7 @@ faye-websocket@~0.11.1:
   dependencies:
     websocket-driver ">=0.5.1"
 
-feather-icons@^4.10.0:
+feather-icons@^4.10:
   version "4.17.0"
   resolved "https://registry.yarnpkg.com/feather-icons/-/feather-icons-4.17.0.tgz#45bd49d05134c6db1f8161c0fe648eb5fb7c4aea"
   integrity sha512-eAQCGeI9Dn57JRuzb7SfWYSj/v/PLoa7cZ1nqY3m0V8i+Q3pqJu6sXiKBRFTufT7s+7o6ZZkDsffh7dsnStSOg==
@@ -4471,7 +4471,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5:
+lodash@^4.17, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -7405,7 +7405,7 @@ vue-eslint-parser@^4.0.2:
     esquery "^1.0.1"
     lodash "^4.17.11"
 
-vue-feather-icons@^4.7.1:
+vue-feather-icons@^4.7:
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/vue-feather-icons/-/vue-feather-icons-4.10.0.tgz#84b699fe148b709ff3f609fc94eed44b078f1c27"
   integrity sha512-fmL/v7DN9HYqnkR7h16PvoMgUk41kxqgqv7yPCAcW4nXRaX1dKgnLwm8m5R2Lpu0NxwpYzRKeTvOs+ti3KaqSg==
@@ -7427,11 +7427,6 @@ vue-loader@^15.4.2:
     loader-utils "^1.1.0"
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
-
-vue-material-design-icons@^2.6.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/vue-material-design-icons/-/vue-material-design-icons-2.8.0.tgz#69a2a337d4356a01fe7c1c092d058834ac1252c6"
-  integrity sha512-/vVQVNv5EDB9uR2fnlux4CQk7HgkSzXhS5XEr2xLsLyzt0GB8XtLgc13QIOpieU8fMhRvr/t8HkM8Riaq/6Fjw==
 
 vue-on-click-outside@^1.0.3:
   version "1.0.3"
@@ -7459,7 +7454,7 @@ vue-svgicon@^3.2.2:
     vue "^2.5.16"
     yargs "^12.0.1"
 
-vue-template-compiler@^2.5.21:
+vue-template-compiler@^2.6.0:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.3.tgz#fe76b7755b038889f5e887895745f0d2bce3f778"
   integrity sha512-SQ3lJk7fwquz8fGac7MwvP9cEBZntokTWITaDrLC0zmyBKjcOfJtWZkMsv+2uSUBDD8kwz8Bsad9xmBWaNULhg==
@@ -7472,7 +7467,7 @@ vue-template-es2015-compiler@^1.8.2:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.8.2.tgz#dd73e80ba58bb65dd7a8aa2aeef6089cf6116f2a"
   integrity sha512-cliV19VHLJqFUYbz/XeWXe5CO6guzwd0yrrqqp0bmjlMP3ZZULY7fu8RTC4+3lmHwo6ESVDHFDsvjB15hcR5IA==
 
-vue@^2.5.16, vue@^2.5.17:
+vue@^2.5.16, vue@^2.6.0:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.3.tgz#180017ba25b94a9864b2921db8644e1062ea82a0"
   integrity sha512-yftjtahz4UTAtOlXXuw7UaYD86fWrMDAAzqTdqJJx2FIBqcPmBN6kPBHiBJFGaQELVblb5ijbFMXsx0i0F7q3g==


### PR DESCRIPTION
This updates our dependencies to Vue 2.6 and updates the scoped slots used in the pickers to the new syntax introduced in the release.