### PR TITLE
Make models more consistent

### DIFF
--- a/nova/config/auth.php
+++ b/nova/config/auth.php
@@ -68,7 +68,7 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => Nova\Users\User::class,
+            'model' => Nova\Users\Models\User::class,
         ],
 
         // 'users' => [

--- a/nova/config/services.php
+++ b/nova/config/services.php
@@ -35,7 +35,7 @@ return [
     ],
 
     'stripe' => [
-        'model' => Nova\Users\User::class,
+        'model' => Nova\Users\Models\User::class,
         'key' => env('STRIPE_KEY'),
         'secret' => env('STRIPE_SECRET'),
         'webhook' => [

--- a/nova/database/factories/UserFactory.php
+++ b/nova/database/factories/UserFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-use Nova\Users\User;
+use Nova\Users\Models\User;
 use Illuminate\Support\Str;
 use Faker\Generator as Faker;
 use Illuminate\Support\Facades\Hash;

--- a/nova/database/seeds/UserSeeder.php
+++ b/nova/database/seeds/UserSeeder.php
@@ -1,6 +1,6 @@
 <?php
 
-use Nova\Users\User;
+use Nova\Users\Models\User;
 use Illuminate\Database\Seeder;
 
 class UserSeeder extends Seeder

--- a/nova/resources/views/components/layouts/app-sidebar.blade.php
+++ b/nova/resources/views/components/layouts/app-sidebar.blade.php
@@ -82,7 +82,7 @@
             </a>
 
             <div class="flex items-center">
-                <user-avatar :user="{{ Nova\Users\User::first() }}" :show-meta="false"></user-avatar>
+                <user-avatar :user="{{ Nova\Users\Models\User::first() }}" :show-meta="false"></user-avatar>
                 {{-- <avatar :item="{{ $_user->toJson() }}"
                         :show-content="false"
                         :show-status="false"

--- a/nova/src/Auth/Http/Controllers/RegisterController.php
+++ b/nova/src/Auth/Http/Controllers/RegisterController.php
@@ -2,7 +2,7 @@
 
 namespace Nova\Auth\Http\Controllers;
 
-use Nova\Users\User;
+use Nova\Users\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Foundation\Auth\RegistersUsers;
@@ -59,7 +59,7 @@ class RegisterController extends Controller
      * Create a new user instance after a valid registration.
      *
      * @param  array  $data
-     * @return \Nova\Users\User
+     * @return \Nova\Users\Models\User
      */
     protected function create(array $data)
     {

--- a/nova/src/Roles/Http/Controllers/RoleController.php
+++ b/nova/src/Roles/Http/Controllers/RoleController.php
@@ -38,8 +38,6 @@ class RoleController extends Controller
     {
         $role = dispatch_now(new Jobs\Create($request->validated()));
 
-        event(new Events\Created($role));
-
         return $role->fresh();
     }
 
@@ -54,16 +52,12 @@ class RoleController extends Controller
     {
         $role = dispatch_now(new Jobs\Update($role, $request->validated()));
 
-        event(new Events\Updated($role));
-
         return $role->fresh();
     }
 
     public function destroy(Authorizers\Destroy $gate, Role $role)
     {
         $role = dispatch_now(new Jobs\Delete($role));
-
-        event(new Events\Deleted($role));
 
         return $role;
     }

--- a/nova/src/Roles/Models/Role.php
+++ b/nova/src/Roles/Models/Role.php
@@ -2,8 +2,16 @@
 
 namespace Nova\Roles\Models;
 
+use Nova\Roles\Events;
 use Silber\Bouncer\Database\Role as BouncerRole;
 
 class Role extends BouncerRole
 {
+
+    protected $dispatchesEvents = [
+        'created' => Events\Created::class,
+        'updated' => Events\Updated::class,
+        'deleted' => Events\Deleted::class,
+        'replicated' => Events\Duplicated::class,
+    ];
 }

--- a/nova/src/Themes/Http/Controllers/ThemeController.php
+++ b/nova/src/Themes/Http/Controllers/ThemeController.php
@@ -38,8 +38,6 @@ class ThemeController extends Controller
     {
         $theme = dispatch_now(new Jobs\Create($request->validated()));
 
-        event(new Events\Created($theme));
-
         return $theme->fresh();
     }
 
@@ -53,16 +51,12 @@ class ThemeController extends Controller
     {
         $theme = dispatch_now(new Jobs\Update($theme, $request->validated()));
 
-        event(new Events\Updated($theme->fresh()));
-
         return $theme->fresh();
     }
 
     public function destroy(Authorizers\Destroy $auth, Theme $theme)
     {
         $theme = dispatch_now(new Jobs\Delete($theme));
-
-        event(new Events\Deleted($theme));
 
         return $theme;
     }

--- a/nova/src/Users/Events/AdminCreated.php
+++ b/nova/src/Users/Events/AdminCreated.php
@@ -6,7 +6,7 @@ use Nova\Users\Models\User;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Foundation\Events\Dispatchable;
 
-class Updated
+class AdminCreated
 {
     use Dispatchable, SerializesModels;
 

--- a/nova/src/Users/Events/AdminDeleted.php
+++ b/nova/src/Users/Events/AdminDeleted.php
@@ -6,7 +6,7 @@ use Nova\Users\Models\User;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Foundation\Events\Dispatchable;
 
-class Updated
+class AdminDeleted
 {
     use Dispatchable, SerializesModels;
 

--- a/nova/src/Users/Events/AdminUpdated.php
+++ b/nova/src/Users/Events/AdminUpdated.php
@@ -6,7 +6,7 @@ use Nova\Users\Models\User;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Foundation\Events\Dispatchable;
 
-class Updated
+class AdminUpdated
 {
     use Dispatchable, SerializesModels;
 

--- a/nova/src/Users/Events/Created.php
+++ b/nova/src/Users/Events/Created.php
@@ -2,7 +2,7 @@
 
 namespace Nova\Users\Events;
 
-use Nova\Users\User;
+use Nova\Users\Models\User;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Foundation\Events\Dispatchable;
 

--- a/nova/src/Users/Events/Deleted.php
+++ b/nova/src/Users/Events/Deleted.php
@@ -2,7 +2,7 @@
 
 namespace Nova\Users\Events;
 
-use Nova\Users\User;
+use Nova\Users\Models\User;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Foundation\Events\Dispatchable;
 

--- a/nova/src/Users/Http/Controllers/UserController.php
+++ b/nova/src/Users/Http/Controllers/UserController.php
@@ -2,7 +2,7 @@
 
 namespace Nova\Users\Http\Controllers;
 
-use Nova\Users\User;
+use Nova\Users\Models\User;
 use Nova\Users\Jobs;
 use Nova\Users\Events;
 use Nova\Roles\Models\Role;
@@ -40,7 +40,7 @@ class UserController extends Controller
     {
         $user = dispatch_now(new Jobs\Create($request->validated()));
 
-        event(new Events\Created($user));
+        event(new Events\AdminCreated($user));
 
         return $user->fresh();
     }
@@ -56,7 +56,7 @@ class UserController extends Controller
     {
         $user = dispatch_now(new Jobs\Update($user, $request->validated()));
 
-        event(new Events\Updated($user->fresh()));
+        event(new Events\AdminUpdated($user->fresh()));
 
         return $user->fresh();
     }
@@ -65,7 +65,7 @@ class UserController extends Controller
     {
         $user = dispatch_now(new Jobs\Delete($user));
 
-        event(new Events\Deleted($user));
+        event(new Events\AdminDeleted($user));
 
         return $user;
     }

--- a/nova/src/Users/Jobs/Create.php
+++ b/nova/src/Users/Jobs/Create.php
@@ -2,7 +2,7 @@
 
 namespace Nova\Users\Jobs;
 
-use Nova\Users\User;
+use Nova\Users\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;

--- a/nova/src/Users/Jobs/Delete.php
+++ b/nova/src/Users/Jobs/Delete.php
@@ -2,7 +2,7 @@
 
 namespace Nova\Users\Jobs;
 
-use Nova\Users\User;
+use Nova\Users\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;

--- a/nova/src/Users/Jobs/Update.php
+++ b/nova/src/Users/Jobs/Update.php
@@ -2,7 +2,7 @@
 
 namespace Nova\Users\Jobs;
 
-use Nova\Users\User;
+use Nova\Users\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;

--- a/nova/src/Users/Listeners/GeneratePassword.php
+++ b/nova/src/Users/Listeners/GeneratePassword.php
@@ -2,8 +2,8 @@
 
 namespace Nova\Users\Listeners;
 
-use Nova\Users\Events\Created;
 use Nova\Foundation\WordGenerator;
+use Nova\Users\Events\AdminCreated;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Nova\Users\Notifications\AccountCreated;
@@ -12,7 +12,7 @@ class GeneratePassword implements ShouldQueue
 {
     use InteractsWithQueue;
 
-    public function handle(Created $event)
+    public function handle(AdminCreated $event)
     {
         $password = implode('-', (new WordGenerator)->words(4));
 

--- a/nova/src/Users/Mail/SendAccountCreation.php
+++ b/nova/src/Users/Mail/SendAccountCreation.php
@@ -2,7 +2,7 @@
 
 namespace Nova\Users\Mail;
 
-use Nova\Users\User;
+use Nova\Users\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;

--- a/nova/src/Users/Models/User.php
+++ b/nova/src/Users/Models/User.php
@@ -1,7 +1,9 @@
 <?php
 
-namespace Nova\Users;
+namespace Nova\Users\Models;
 
+use Nova\Users\Events;
+use Nova\Users\UsersCollection;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
@@ -28,10 +30,16 @@ class User extends Authenticatable implements MustVerifyEmail
         'last_login',
     ];
 
+    protected $dispatchesEvents = [
+        'created' => Events\Created::class,
+        'updated' => Events\Updated::class,
+        'deleted' => Events\Deleted::class,
+    ];
+
     /**
      * Record a timestamp when a user logs in.
      *
-     * @return \Nova\Users\User
+     * @return \Nova\Users\Models\User
      */
     public function recordLoginTime()
     {
@@ -43,7 +51,7 @@ class User extends Authenticatable implements MustVerifyEmail
     /**
      * Force the user to reset their password.
      *
-     * @return \Nova\Users\User
+     * @return \Nova\Users\Models\User
      */
     public function forcePasswordReset()
     {
@@ -56,7 +64,7 @@ class User extends Authenticatable implements MustVerifyEmail
      * Create a new Eloquent Collection instance.
      *
      * @param  array  $models
-     * @return \Nova\Users\UsersCollection
+     * @return \Nova\Users\Models\UsersCollection
      */
     public function newCollection(array $models = [])
     {

--- a/nova/src/Users/Providers/UserServiceProvider.php
+++ b/nova/src/Users/Providers/UserServiceProvider.php
@@ -15,7 +15,7 @@ class UserServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->app['events']->listen(Events\Created::class, Listeners\GeneratePassword::class);
+        $this->app['events']->listen(Events\AdminCreated::class, Listeners\GeneratePassword::class);
     }
 
     /**

--- a/nova/tests/Feature/Auth/ResetPasswordTest.php
+++ b/nova/tests/Feature/Auth/ResetPasswordTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Feature\Auth;
 
 use Tests\TestCase;
-use Nova\Users\User;
+use Nova\Users\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Password;

--- a/nova/tests/Feature/Users/CreateUserTest.php
+++ b/nova/tests/Feature/Users/CreateUserTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Feature\Users;
 
 use Tests\TestCase;
-use Nova\Users\User;
+use Nova\Users\Models\User;
 use Nova\Users\Events;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
@@ -57,7 +57,7 @@ class CreateUserTest extends TestCase
         ]);
     }
 
-    public function testEventIsDispatchedWhenUserIsCreated()
+    public function testEventsAreDispatchedWhenUserIsCreated()
     {
         Event::fake();
 
@@ -66,6 +66,10 @@ class CreateUserTest extends TestCase
         $this->postJson(route('users.store'), factory(User::class)->make()->toArray());
 
         $user = User::get()->last();
+
+        Event::assertDispatched(Events\AdminCreated::class, function ($event) use ($user) {
+            return $event->user->is($user);
+        });
 
         Event::assertDispatched(Events\Created::class, function ($event) use ($user) {
             return $event->user->is($user);

--- a/nova/tests/Feature/Users/DeleteUserTest.php
+++ b/nova/tests/Feature/Users/DeleteUserTest.php
@@ -4,7 +4,7 @@ namespace Tests\Feature\Users;
 
 use Tests\TestCase;
 use Nova\Users\Events;
-use Nova\Users\User;
+use Nova\Users\Models\User;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -70,7 +70,7 @@ class DeleteUserTest extends TestCase
         ]);
     }
 
-    public function testEventIsDispatchedWhenUserIsDeleted()
+    public function testEventsAreDispatchedWhenUserIsDeleted()
     {
         Event::fake();
 
@@ -79,6 +79,10 @@ class DeleteUserTest extends TestCase
         $this->deleteJson(route('users.destroy', $this->user));
 
         Event::assertDispatched(Events\Deleted::class, function ($event) {
+            return $event->user->is($this->user);
+        });
+
+        Event::assertDispatched(Events\AdminDeleted::class, function ($event) {
             return $event->user->is($this->user);
         });
     }

--- a/nova/tests/Feature/Users/UpdateUserTest.php
+++ b/nova/tests/Feature/Users/UpdateUserTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Feature\Users;
 
 use Tests\TestCase;
-use Nova\Users\User;
+use Nova\Users\Models\User;
 use Nova\Users\Events;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
@@ -64,7 +64,7 @@ class UpdateUserTest extends TestCase
         });
     }
 
-    public function testEventIsDispatchedWhenUserIsUpdated()
+    public function testEventsAreDispatchedWhenUserIsUpdated()
     {
         Event::fake();
 
@@ -75,6 +75,10 @@ class UpdateUserTest extends TestCase
         $user = $this->user->fresh();
 
         Event::assertDispatched(Events\Updated::class, function ($event) use ($user) {
+            return $event->user->is($user);
+        });
+
+        Event::assertDispatched(Events\AdminUpdated::class, function ($event) use ($user) {
             return $event->user->is($user);
         });
     }

--- a/nova/tests/ManagesTestUsers.php
+++ b/nova/tests/ManagesTestUsers.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use Nova\Users\User;
+use Nova\Users\Models\User;
 
 trait ManagesTestUsers
 {


### PR DESCRIPTION
- Move all models to a `Models` namespace
- Make sure all models use the `$dispatchesEvents`
- Remove the event firing from the controllers
- Add `Admin...` events to the `users` domain so that we can target admin actions on users